### PR TITLE
LE-13: Close the splash screen after the map is ready to be shown

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -21,8 +21,8 @@
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />
     <preference name="SplashShowOnlyFirstTime" value="false" />
+    <preference name="AutoHideSplashScreen" value="false" />
     <preference name="SplashScreen" value="screen" />
-    <preference name="SplashScreenDelay" value="6000" />
     <platform name="android">
         <allow-intent href="market:*" />
         <icon density="ldpi" src="resources/android/icon/drawable-ldpi-icon.png" />

--- a/src/components/map/map.ts
+++ b/src/components/map/map.ts
@@ -3,6 +3,7 @@ import {GeoLocComponent} from "../geo-loc/geo-loc";
 import {isDefined} from "ionic-angular/util/util";
 import {MarkersComponent} from "../markers/markers";
 import LatLngExpression = L.LatLngExpression;
+import {SplashScreen} from "@ionic-native/splash-screen";
 
 /**
  * Generated class for the MapComponent component.
@@ -22,13 +23,16 @@ export class MapComponent {
   map: any;
   lastPosition: [number, number];
   private autoCenter: boolean = false;
+  private splashScreen: SplashScreen;
 
   constructor(
     public geoLoc: GeoLocComponent,
-    private markers: MarkersComponent
+    private markers: MarkersComponent,
+    private screen: SplashScreen
   ) {
     this.zoomLevel = 14;
     this.lastPosition = [33.77, -84.37];
+    this.splashScreen = screen;
   }
 
   public setWatch() {
@@ -68,6 +72,9 @@ export class MapComponent {
           position,
           this.zoomLevel
         );
+
+        /* Map is ready; turn off splash screen. */
+        this.splashScreen.hide();
       }
     );
 


### PR DESCRIPTION
- Configured map to no longer auto hide.
- Requesting the splash screen to be hidden after we get our first
position back and the map has been centered at current location.